### PR TITLE
Fixed parameters in calling PriceCalculator.get_base_packing_price_gross()

### DIFF
--- a/lfs/catalog/models.py
+++ b/lfs/catalog/models.py
@@ -911,7 +911,7 @@ class Product(models.Model):
         See lfs.plugins.PriceCalculator
         """
         pc = self.get_price_calculator(request)
-        return pc.get_base_packing_price_gross(request)
+        return pc.get_base_packing_price_gross()
 
     # TODO: Check whether there is a test case for that and write one if not.
     def get_for_sale(self):


### PR DESCRIPTION
There is no "request" argument in get_base_packing_price_gross.
