### PR TITLE
It's impossible to check off "Active packing" and "Active base price" checkboxes.

### DIFF
--- a/lfs/manage/product/product.py
+++ b/lfs/manage/product/product.py
@@ -71,7 +71,7 @@ class ProductDataForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(ProductDataForm, self).__init__(*args, **kwargs)
         self.fields["template"].widget = SelectImage(choices=PRODUCT_TEMPLATES)
-        self.fields["active_base_price"].widget = CheckboxInput()
+        self.fields["active_base_price"].widget = CheckboxInput(check_test=lambda v:v!=0)
         man_count = Manufacturer.objects.count()
         if man_count > getattr(settings, 'LFS_SELECT_LIMIT', 20):
             self.fields["manufacturer"].widget = HiddenInput()
@@ -149,7 +149,7 @@ class ProductStockForm(forms.ModelForm):
         if kwargs.get("instance").is_variant():
             self.fields["active_packing_unit"].widget = Select(choices=CHOICES)
         else:
-            self.fields["active_packing_unit"].widget = CheckboxInput()
+            self.fields["active_packing_unit"].widget = CheckboxInput(check_test=lambda v:v!=0)
 
     def clean(self):
         if self.data.get("stock-active_packing_unit") == str(CHOICES_YES):


### PR DESCRIPTION
Product model use PositiveSmallIntegerField for active_packing_unit and active_base_price fields. Value of that fields can be either 0, or 1.
CheckBoxInput widget use this code to decide when  checkbox must be checked: `lambda v: not (v is False or v is None or v == '')` [django/forms/widgets.py#496](https://github.com/django/django/blob/1cd18f4cfdaf5f4a4002e9c59e1146e5fa0d70d3/django/forms/widgets.py#L496) and [#503](https://github.com/django/django/blob/1cd18f4cfdaf5f4a4002e9c59e1146e5fa0d70d3/django/forms/widgets.py#L503)

so, both values of the fields check that chekboxes.

Best solution will be change active_bla_bla to BooleanField, but this patch is fine too.
