### PR TITLE
Small fix that allows to override default form for management SEOView

### DIFF
--- a/lfs/manage/seo/views.py
+++ b/lfs/manage/seo/views.py
@@ -40,11 +40,11 @@ class SEOView(View):
 
     def __init__(self, model_klass, form_klass=None, template_name='manage/seo/seo.html', *args, **kwargs):
         super(SEOView, self).__init__(*args, **kwargs)
-        if not form_klass:
+        form_k = form_klass if form_klass else self.form_klass
+        if not form_k:
             # if form_klass is not specified then prepare default model form for SEO management
-            form_klass = modelform_factory(model_klass,
-                                           fields=("meta_title", "meta_keywords", "meta_description"))
-        self.form_klass = form_klass
+            self.form_klass = modelform_factory(model_klass,
+                                                fields=("meta_title", "meta_keywords", "meta_description"))
         self.model_klass = model_klass
         self.template_name = template_name
 


### PR DESCRIPTION
Small fix that allows to override default form for management SEOView, like:

``` python
class PageSEOView(SEOView):
    form_klass = PageSEOForm
```
