### PR TITLE
Fixed datepicker assignment at the management interface

### DIFF
--- a/lfs/static/js/lfs.manage.js
+++ b/lfs/static/js/lfs.manage.js
@@ -39,6 +39,14 @@ function update_positions() {
     });
 };
 
+function setup_datepicker(){
+    $("input.date-picker").datepicker({
+        dateFormat: 'yy-mm-dd',
+        showWeek: true,
+        firstDay: 1
+    });
+}
+
 function send_form_and_refresh(mythis) {
     mythis.parents("form:first").ajaxSubmit({
         success : function(data) {
@@ -180,6 +188,7 @@ $(function() {
                 }
                 hide_ajax_loading();
                 update_editor();
+                setup_datepicker();
 
                 // trigger form-save-end event when new HTML has already been injected into page
                 var event = jQuery.Event("form-save-end");
@@ -441,11 +450,7 @@ $(function() {
         return false;
     })
 
-    $("input.date-picker").datepicker({
-        dateFormat: 'yy-mm-dd',
-        showWeek: true,
-        firstDay: 1
-    });
+    setup_datepicker();
 
     $('ol.sortable').nestedSortable({
         placeholder: 'placeholder',


### PR DESCRIPTION
So far datepicker was assigned to input.date-picker fields only once (when page was loaded) which caused that, eg. after tab was saved, datepicker no longer worked. This issue appeared eg. at Stock tab at product management form.
This commit fixes this
