### PR TITLE
Changed South requirement from fixed 0.7.3 version to 0.7.x branch excluded broken 0.7.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(name='django-lfs',
         'lfs-order-numbers == 1.0b1',
         'lfs-paypal == 1.0b1',
         'Pillow == 1.7.5',
-        'South == 0.7.3',
+        'South >=0.7,!=0.7.4',
       ],
       )


### PR DESCRIPTION
I thinnk it is good idea to have version range rather than fixed version. South has been updated and some projects may use the updated version. Also my experience with South shows that any South version works fine at most situations.
