### PR TITLE
include app's urls only if the app is in INSTALLED_APPS

### DIFF
--- a/lfs/core/urls.py
+++ b/lfs/core/urls.py
@@ -1,4 +1,5 @@
 # django imports
+from django.conf import settings
 from django.conf.urls.defaults import *
 from django.views.generic.simple import direct_to_template
 
@@ -106,13 +107,15 @@ urlpatterns += patterns('lfs.search.views',
 )
 
 # Tagging
-urlpatterns += patterns('',
-    (r'^tagging/', include('lfs.tagging.urls')),
-)
+if 'lfs.tagging' in settings.INSTALLED_APPS:
+    urlpatterns += patterns('',
+        (r'^tagging/', include('lfs.tagging.urls')),
+    )
 
-urlpatterns += patterns('',
-    (r'', include('lfs_contact.urls')),
-)
+if 'lfs_contact' in settings.INSTALLED_APPS:
+    urlpatterns += patterns('',
+        (r'', include('lfs_contact.urls')),
+    )
 
 
 one_time_setup()


### PR DESCRIPTION
I do not know whether will work the current stable version without lfs.tagging, but it is better to check if an app is installed before include the urls.
