### PR TITLE
ensure that our addresses get deep copied when creating an order

### DIFF
--- a/lfs/order/tests.py
+++ b/lfs/order/tests.py
@@ -132,7 +132,13 @@ class OrderTestCase(TestCase):
     def test_add_order(self):
         """Tests the general adding of an order via the add_order method
         """
+        # check we have 2 addresses before the order
+        self.assertEqual(2, Address.objects.count())
+
         order = add_order(self.request)
+
+        # adding an order should deep copy our addresses above
+        self.assertEqual(4, Address.objects.count())
 
         self.assertEqual(order.state, SUBMITTED)
         self.assertEqual("%.2f" % order.price, "9.80")

--- a/lfs/order/utils.py
+++ b/lfs/order/utils.py
@@ -97,10 +97,12 @@ def add_order(request):
     # Copy addresses
     invoice_address = deepcopy(invoice_address)
     invoice_address.id = None
+    invoice_address.pk = None
     invoice_address.save()
 
     shipping_address = deepcopy(shipping_address)
     shipping_address.id = None
+    shipping_address.pk = None
     shipping_address.save()
 
     order = Order.objects.create(


### PR DESCRIPTION
Need to set id and pk to None when copying an inherited model https://docs.djangoproject.com/en/1.4/topics/db/queries/#copying-model-instances
