### PR TITLE
Exclude children of products with variants

### DIFF
--- a/lfs/core/sitemap.py
+++ b/lfs/core/sitemap.py
@@ -15,7 +15,6 @@ class ProductSitemap(Sitemap):
     changefreq = "weekly"
     priority = 0.5
 
-    # So we just get standard products and the parents of products with variants
     def items(self):
         return Product.objects.filter(active=True).exclude(sub_type=2)
 


### PR DESCRIPTION
The sitemap is crowded by active children of inactive parents. So we end up with a lot of 404s.
By just excluding the children, we only get the active parents.
Cheers
Jo
