### PR TITLE
Check if cart has been initiated in refresh_cart view

### DIFF
--- a/lfs/cart/views.py
+++ b/lfs/cart/views.py
@@ -382,6 +382,8 @@ def refresh_cart(request):
     amount of a product or shipping/payment method.
     """
     cart = cart_utils.get_cart(request)
+    if not cart:
+        raise Http404
     customer = customer_utils.get_or_create_customer(request)
 
     # Update country


### PR DESCRIPTION
To avoid the "AttributeError: 'NoneType' object has no attribute 'get_items'"(lfs/cart/views.py, line 394, in refresh_cart).
As we already do in delete_cart_item view.
