### PR TITLE
fixed ajax-loader path for file uploader

### DIFF
--- a/lfs/static/js/lfs.manage.product.js
+++ b/lfs/static/js/lfs.manage.product.js
@@ -54,7 +54,7 @@ $(function() {
             var msg = $("#files").attr("msg");
             return $(
                 '<tr>' +
-                '<td><div style="font-weight:bold; padding-bottom:10px">' + msg + '<img src="{{ STATIC_URL }}img/ajax-loader.gif" style="padding:8px 0 0 10px" /></div>' + fileNames + '<\/td>' +
+                '<td><div style="font-weight:bold; padding-bottom:10px">' + msg + '<img src="' + STATIC_URL + 'img/ajax-loader.gif" style="padding:8px 0 0 10px" /></div>' + fileNames + '<\/td>' +
                 '<\/tr>'
             );
         },


### PR DESCRIPTION
Fix to use JS variable instead of django templates variable syntax that's not valid for JS files.
