### PR TITLE
Removed create_table from migrate_to_09

### DIFF
--- a/lfs/core/management/commands/lfs_migrate.py
+++ b/lfs/core/management/commands/lfs_migrate.py
@@ -544,15 +544,6 @@ class Command(BaseCommand):
         paypal.module = "lfs_paypal.PayPalProcessor"
         paypal.save()
 
-        # Adding model 'LatestPortlet'
-        db.create_table('portlet_latestportlet', (
-            ('id', models.fields.AutoField(primary_key=True)),
-            ('title', models.fields.CharField(max_length=100, blank=True)),
-            ('limit', models.fields.IntegerField(default=5)),
-            ('current_category', models.fields.BooleanField(default=False)),
-            ('slideshow', models.fields.BooleanField(default=False)),
-        ))
-
         application.version = "0.9"
         application.save()
 


### PR DESCRIPTION
Removed the creation of 'LatestPortlet' table from migrate_to_09 as this operation will be performed in 0002 migration of portlet app.
Or we can leave here this code and fake the respective 0002 migration.
