### PR TITLE
Fixes an opposite value of "deliverable" variable

### DIFF
--- a/lfs/shipping/utils.py
+++ b/lfs/shipping/utils.py
@@ -202,13 +202,8 @@ def get_shipping_costs(request, shipping_method):
 def get_delivery_time(request, product):
     """Returns delivery time for given product.
     """
-    if product.is_deliverable():
-        return {
-            "deliverable": False,
-            "delivery_time": get_product_delivery_time(request, product)
-        }
-    else:
-        return {
-            "deliverable": True,
-            "delivery_time": get_product_delivery_time(request, product)
-        }
+    
+    return {
+        "deliverable": product.is_deliverable(),
+        "delivery_time": get_product_delivery_time(request, product)
+    }


### PR DESCRIPTION
It looks like a typo. Otherwise, why is returned an opposite of a `product.is_deliverable`?