### PR TITLE
Use GET with ajax-link

### DIFF
--- a/lfs/manage/static/lfs/js/lfs.manage.js
+++ b/lfs/manage/static/lfs/js/lfs.manage.js
@@ -216,7 +216,7 @@ $(function() {
     // Generic ajax link
     $body.on('click', ".ajax-link", function() {
         var url = $(this).attr("href");
-        $.post(url, function(data) {
+        $.get(url, function(data) {
             data = safeParseJSON(data);
             for (var html in data["html"])
                 $(data["html"][html][0]).html(data["html"][html][1]);


### PR DESCRIPTION
Currently we're using links like:

    <a class="ajax-link" href="{% url 'lfs_orders_inline' %}?page=1">

and these are being sent with POST. There are two issues:

1. It doesn't work with server side construct like:
    `page = (request.POST if request.method == 'POST' else request.GET).get("page", 1)`

    that is used instead of request.REQUEST in older Django versions

2. It is not consistent to use POST and send parameters with GET

My proposal is to just use $.get

