### PR TITLE
Remove celery integration

### DIFF
--- a/docs/user/howtos/how_to_use_celery.rst
+++ b/docs/user/howtos/how_to_use_celery.rst
@@ -5,76 +5,24 @@ How To Use Celery
 Overview
 ========
 
-In this how-to you will learn how to use ``Celery`` with LFS. It is used to send
-e-mails from LFS asynchronously.
+``Celery`` is a distributed task queue that can be used to send e-mails from LFS asynchronously.
 
-``Celery`` is integrated with LFS by default. If it is installed and properly
-set up LFS will make use of it. If not LFS, will work as expected, though.
+There is no special integration in LFS for ``Celery`` but there are general patterns for Django based projects
+that can be used to get asynchronous e-mail backend.
 
-Install Celery
-==============
+Dependencies
+============
 
-To install ``Celery`` proceed the following steps:
+You need:
 
-#. $ pip install django-celery
+ * `celery <http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html>`_
+ * `django-celery-email <https://pypi.python.org/pypi/django-celery-email>`_
 
-#. Add the following lines to settings.py::
+as well as some Celery backend, eg Redis. Consult Celery documentation for details.
 
-    import djcelery
-    djcelery.setup_loader()
 
-#. Add ``djcelery`` and ``kombu.transport.django`` to ``INSTALLED_APPS``::
+Installation
+============
 
-    INSTALLED_APPS = (
-        "...",
-        "djcelery",
-        "kombu.transport.django", # only needed when the broker is Django's database
-    )
-
-#. Sync your database::
-
-    $ bin/django syncdb
-
-#. Add a broker to ``settings.py``::
-
-    BROKER_URL = "django://"
-
-#. Start ``Celery``::
-
-    $ bin/django celeryd --loglevel info
-
-Note
-====
-
-This is the easiest way to setup ``Celery`` with LFS, which uses Django's
-database as broker. You might want to use another broker to make use of all
-features of ``Celery``. For that please refer to the excellent `documentation of
-celery <http://docs.celeryproject.org/en/latest/index.html>`_.
-
-Running Celery as a Deamon
-==========================
-
-In a production environment you might want to start ``Celery`` as deamon. To
-make things easier we provide a init.d and a belonging configure script as a
-start (both are heavily based on the examples of the ``Celery`` documentation).
-Please see https://github.com/diefenbach/celery.
-
-To start ``Celery`` as daemon:
-
-* Put both scripts into the same directory
-
-* Adapt the settings within celery.cfg and
-
-* Execute celery.sh like::
-
-    $ ./celery.sh start
-
-.. seealso::
-
-    `Running celeryd as a daemon <http://docs.celeryq.org/en/latest/cookbook/daemonizing.html>`_
-
-See Also
-========
-
-* `Celery homepage <http://celeryproject.org/>`_
-* `Celery with Django <http://docs.celeryproject.org/en/latest/django/index.html>`_
+Follow the Celery's `first steps with Django <http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html>`_
+and django-celery-email `documentation <https://pypi.python.org/pypi/django-celery-email>`_.

--- a/lfs/mail/utils.py
+++ b/lfs/mail/utils.py
@@ -10,13 +10,6 @@ from django.utils.translation import ugettext_lazy as _
 
 
 def send_order_sent_mail(order):
-    try:
-        _send_order_sent_mail.delay(order)
-    except AttributeError:
-        _send_order_sent_mail(order)
-
-
-def _send_order_sent_mail(order):
     """Sends an order has been sent mail to the shop customer
     """
     import lfs.core.utils
@@ -46,13 +39,6 @@ def _send_order_sent_mail(order):
 
 
 def send_order_paid_mail(order):
-    try:
-        _send_order_paid_mail.delay(order)
-    except AttributeError:
-        _send_order_paid_mail(order)
-
-
-def _send_order_paid_mail(order):
     """Sends an order has been paid mail to the shop customer.
     """
     import lfs.core.utils
@@ -82,13 +68,6 @@ def _send_order_paid_mail(order):
 
 
 def send_order_received_mail(request, order):
-    try:
-        _send_order_received_mail.delay(request, order)
-    except AttributeError:
-        _send_order_received_mail(request, order)
-
-
-def _send_order_received_mail(request, order):
     """Sends an order received mail to the shop customer.
 
     Customer information is taken from the provided order.
@@ -120,13 +99,6 @@ def _send_order_received_mail(request, order):
 
 
 def send_customer_added(user):
-    try:
-        _send_customer_added.delay(user)
-    except AttributeError:
-        _send_customer_added(user)
-
-
-def _send_customer_added(user):
     """Sends a mail to a newly registered user.
     """
     import lfs.core.utils
@@ -157,13 +129,6 @@ def _send_customer_added(user):
 
 
 def send_review_added(review):
-    try:
-        _send_review_added.delay(review)
-    except AttributeError:
-        _send_review_added(review)
-
-
-def _send_review_added(review):
     """Sends a mail to shop admins that a new review has been added
     """
     import lfs.core.utils
@@ -195,15 +160,3 @@ def _send_review_added(review):
     mail.attach_alternative(html, "text/html")
     mail.send(fail_silently=True)
 
-
-# celery
-try:
-    from celery.task import task
-except ImportError:
-    pass
-else:
-    _send_customer_added = task(_send_customer_added)
-    _send_order_paid_mail = task(_send_order_paid_mail)
-    _send_order_received_mail = task(_send_order_received_mail)
-    _send_order_sent_mail = task(_send_order_sent_mail)
-    _send_review_added = task(_send_review_added)


### PR DESCRIPTION
I'd like to remove celery integration from LFS in favour of using generic Django solutions for asynchronous emails like django-celery-email. 

There is no need to have special code within LFS to support celery based emails. Also, current celery integration is broken. I just got 

> EncodeError
> Can't pickle <type 'uwsgi._Input'>: attribute lookup uwsgi._Input failed

after enabling celery for LFS yesterday. This error is possibly due to the fact that whole request objects is passed as a parameter to celery task in LFS.

The way we have current celery integration makes it impossible to use celery in the project without using LFS celery integration - LFS just checks if celery module is available.

Moreover, current LFS documentation for celery is outdated. Celery has changed a lot since these docs were written. Again, I see no point in maintaining these docs within LFS, unless in very simple way (as it's done in this pull request).