### PR TITLE
Fix cart and customer updates on login

### DIFF
--- a/lfs/customer/tests.py
+++ b/lfs/customer/tests.py
@@ -11,7 +11,8 @@ from lfs.core.models import Country
 from lfs.core.models import Shop
 from lfs.customer.models import CreditCard
 from lfs.customer.models import Customer
-from lfs.customer.utils import create_unique_username, create_customer
+from lfs.customer.utils import create_unique_username
+from lfs.customer.utils import create_customer
 from lfs.shipping.models import ShippingMethod
 from lfs.tax.models import Tax
 from lfs.payment.models import PaymentMethod


### PR DESCRIPTION
When user logs in then his cart (created for Anonymous user) should be preserved and merged with authenticated user's cart (if any). It doesn't happen now as session_key used by update_cart_after_login is already a new key (due to a call to request.session.cycle_key() in auth->login). Tests for this behaviour are also invalid as these are not triggering default login view.