### PR TITLE
Make RegisterForm configurable with LFS_REGISTER_FORM setting

### DIFF
--- a/docs/developer/settings.rst
+++ b/docs/developer/settings.rst
@@ -174,6 +174,15 @@ LFS_ONE_PAGE_CHECKOUT_FORM
     default value is ``lfs.checkout.forms.OnePageCheckoutForm``.
 
 
+.. _settings_registration:
+
+Registration
+============
+
+LFS_REGISTER_FORM
+    The form that is used during user registration. This setting is optional.
+    The default value is ``lfs.customer.forms.RegisterForm``
+
 
 .. _settings_addresses:
 

--- a/lfs/checkout/views.py
+++ b/lfs/checkout/views.py
@@ -26,7 +26,7 @@ from lfs.customer import utils as customer_utils
 from lfs.customer.utils import create_unique_username
 from lfs.customer.forms import CreditCardForm, CustomerAuthenticationForm
 from lfs.customer.forms import BankAccountForm
-from lfs.customer.forms import RegisterForm
+from lfs.customer.settings import REGISTER_FORM
 from lfs.payment.models import PaymentMethod
 from lfs.voucher.models import Voucher
 
@@ -50,6 +50,7 @@ def login(request, template_name="lfs/checkout/login.html"):
 
     # Using Djangos default AuthenticationForm
     login_form = CustomerAuthenticationForm()
+    RegisterForm = lfs.core.utils.import_symbol(REGISTER_FORM)
     register_form = RegisterForm()
 
     if request.POST.get("action") == "login":

--- a/lfs/customer/settings.py
+++ b/lfs/customer/settings.py
@@ -1,0 +1,5 @@
+# coding: utf-8
+from django.conf import settings
+
+
+REGISTER_FORM = getattr(settings, 'LFS_REGISTER_FORM', 'lfs.customer.forms.RegisterForm')

--- a/lfs/customer/views.py
+++ b/lfs/customer/views.py
@@ -13,10 +13,11 @@ from django.utils.translation import ugettext_lazy as _
 
 # lfs imports
 import lfs
+import lfs.core.utils
 from lfs.addresses.utils import AddressManagement
 from lfs.customer import utils as customer_utils
 from lfs.customer.forms import EmailForm, CustomerAuthenticationForm
-from lfs.customer.forms import RegisterForm
+from lfs.customer.settings import REGISTER_FORM
 from lfs.customer.utils import create_unique_username
 from lfs.order.models import Order
 
@@ -39,6 +40,8 @@ def login(request, template_name="lfs/customer/login.html"):
 
     login_form = CustomerAuthenticationForm()
     login_form.fields["username"].label = _(u"E-Mail")
+
+    RegisterForm = lfs.core.utils.import_symbol(REGISTER_FORM)
     register_form = RegisterForm()
 
     if request.POST.get("action") == "login":


### PR DESCRIPTION
As GDPR comes into force 25th may 2018 it might be required to modify Registration form eg. by adding some extra checkboxes for Terms/PrivacyPolicy confirmation. 
As it seems (at least to me) that it is not very clear (in terms of GDPR regulations) how exaclty this confirmation should look like I think we should at least let users do it by themselves.

This PR makes it possible to easily change RegistrationForm eg. to:

```
class CustomRegisterForm(RegisterForm):
    terms = forms.BooleanField(
        label=mark_safe(u'Hereby I accept site <a href="/page/terms" target="_blank">Terms &amp; Conditions</a> and I've read the <a href="/page/privacy-policy" target="_blank">Privacy policy</a>.'), required=True)
```